### PR TITLE
Pass mailing properties into Smarty templates for subject and body of bounce notifications

### DIFF
--- a/CRM/Utils/Mailboxmailing/BouncesReportProcessor.php
+++ b/CRM/Utils/Mailboxmailing/BouncesReportProcessor.php
@@ -157,6 +157,7 @@ class CRM_Utils_Mailboxmailing_BouncesReportProcessor {
     $variables = CRM_Utils_Mailboxmailing::getSmartyVariables(array(
       'mailSetting' => $mailSetting,
       'bounces' => $bounces,
+      'mailing' => $mailing,
     ));
     $subject = $smarty->fetchWith('string:' . $mailSetting->notify_sender_errors_subject, $variables);
 
@@ -176,6 +177,7 @@ class CRM_Utils_Mailboxmailing_BouncesReportProcessor {
       CRM_Utils_Mailboxmailing::getSmartyVariables(array(
         'mailSetting' => $mailSetting,
         'bounces' => $bounces,
+        'mailing' => $mailing,
       ))
     );
     $mail_params['text'] = $text;

--- a/CRM/Utils/Mailboxmailing/BouncesReportProcessor.php
+++ b/CRM/Utils/Mailboxmailing/BouncesReportProcessor.php
@@ -40,7 +40,9 @@ class CRM_Utils_Mailboxmailing_BouncesReportProcessor {
         'id',
         'created_id',
         'mailing_mailboxmailing.MailboxmailingMailSettingsId',
-        'mailing_mailboxmailing.MailboxmailingBouncesReportCount'
+        'mailing_mailboxmailing.MailboxmailingBouncesReportCount',
+        'subject',
+        'scheduled_date'
       )
       // Only mailings created by the Mailboxmailing extension.
       ->addWhere('mailing_mailboxmailing.MailboxmailingMailSettingsId', 'IS NOT NULL')
@@ -106,6 +108,8 @@ class CRM_Utils_Mailboxmailing_BouncesReportProcessor {
 
       // Set the bounce report count on the mailing.
       // TODO: APIv4 does not set custom field values on Mailing entities, thus using APIv3.
+      //       See https://lab.civicrm.org/dev/core/-/issues/3747.
+      //       See https://github.com/civicrm/civicrm-core/pull/24036 for a fix.
 //      Mailing::update(FALSE)
 //        ->addWhere('id', '=', $mailing['id'])
 //        ->addValue('mailing_mailboxmailing.MailboxmailingBouncesReportCount', $bounce_report_count)

--- a/templates/CRM/Admin/Form/MailboxmailingMailSettings.hlp
+++ b/templates/CRM/Admin/Form/MailboxmailingMailSettings.hlp
@@ -108,30 +108,35 @@
     </li>
 
     <li>
-          <code>{literal}$mailSetting{/literal}</code> - Variables of the mail settings used.
-          <ul>
-            <li><code>{literal}$mailSetting.name{/literal}</code></li>
-            <li><code>{literal}$mailSetting.domain{/literal}</code></li>
-            <li><code>{literal}$mailSetting.localpart{/literal}</code></li>
-            <li><code>{literal}$mailSetting.server{/literal}</code></li>
-            <li><code>{literal}$mailSetting.return_path{/literal}</code></li>
-            <li><code>{literal}$mailSetting.protocol{/literal}</code></li>
-            <li><code>{literal}$mailSetting.port{/literal}</code></li>
-            <li><code>{literal}$mailSetting.username{/literal}</code></li>
-            <li><code>{literal}$mailSetting.password{/literal}</code></li>
-            <li><code>{literal}$mailSetting.source{/literal}</code></li>
-            <li><code>{literal}$mailSetting.is_ssl{/literal}</code></li>
-            <li><code>{literal}$mailSetting.sender_group_id{/literal}</code></li>
-            <li><code>{literal}$mailSetting.recipient_group_id{/literal}</code></li>
-            <li><code>{literal}$mailSetting.subject{/literal}</code></li>
-            <li><code>{literal}$mailSetting.notify_disallowed_sender{/literal}</code></li>
-            <li><code>{literal}$mailSetting.notify_disallowed_sender_template{/literal}</code></li>
-            <li><code>{literal}$mailSetting.notify_sender_errors{/literal}</code></li>
-            <li><code>{literal}$mailSetting.notify_sender_errors_template{/literal}</code></li>
-            <li><code>{literal}$mailSetting.notification_activity_type_id{/literal}</code></li>
-            <li><code>{literal}$mailSetting.archive_mailing{/literal}</code></li>
-          </ul>
-        </li>
+      <code>{literal}$mailSetting{/literal}</code> - Variables of the mail settings used.
+      <ul>
+        <li><code>{literal}$mailSetting.name{/literal}</code></li>
+        <li><code>{literal}$mailSetting.domain{/literal}</code></li>
+        <li><code>{literal}$mailSetting.localpart{/literal}</code></li>
+        <li><code>{literal}$mailSetting.server{/literal}</code></li>
+        <li><code>{literal}$mailSetting.return_path{/literal}</code></li>
+        <li><code>{literal}$mailSetting.protocol{/literal}</code></li>
+        <li><code>{literal}$mailSetting.port{/literal}</code></li>
+        <li><code>{literal}$mailSetting.username{/literal}</code></li>
+        <li><code>{literal}$mailSetting.password{/literal}</code></li>
+        <li><code>{literal}$mailSetting.source{/literal}</code></li>
+        <li><code>{literal}$mailSetting.is_ssl{/literal}</code></li>
+        <li><code>{literal}$mailSetting.sender_group_id{/literal}</code></li>
+        <li><code>{literal}$mailSetting.recipient_group_id{/literal}</code></li>
+        <li><code>{literal}$mailSetting.subject{/literal}</code></li>
+        <li><code>{literal}$mailSetting.notify_disallowed_sender{/literal}</code></li>
+        <li><code>{literal}$mailSetting.notify_disallowed_sender_template{/literal}</code></li>
+        <li><code>{literal}$mailSetting.notify_sender_errors{/literal}</code></li>
+        <li><code>{literal}$mailSetting.notify_sender_errors_template{/literal}</code></li>
+        <li><code>{literal}$mailSetting.notification_activity_type_id{/literal}</code></li>
+        <li><code>{literal}$mailSetting.archive_mailing{/literal}</code></li>
+      </ul>
+    </li>
+
+    <li>
+      <code>{literal}$mailing{/literal}</code> - Variables of the mailing bounces are being processed for.
+    </li>
+
   </ul>
 {/htxt}
 {htxt id='id-notify_sender_errors_subject'}
@@ -150,29 +155,34 @@
     </li>
 
     <li>
-          <code>{literal}$mailSetting{/literal}</code> - Variables of the mail settings used.
-          <ul>
-            <li><code>{literal}$mailSetting.name{/literal}</code></li>
-            <li><code>{literal}$mailSetting.domain{/literal}</code></li>
-            <li><code>{literal}$mailSetting.localpart{/literal}</code></li>
-            <li><code>{literal}$mailSetting.server{/literal}</code></li>
-            <li><code>{literal}$mailSetting.return_path{/literal}</code></li>
-            <li><code>{literal}$mailSetting.protocol{/literal}</code></li>
-            <li><code>{literal}$mailSetting.port{/literal}</code></li>
-            <li><code>{literal}$mailSetting.username{/literal}</code></li>
-            <li><code>{literal}$mailSetting.password{/literal}</code></li>
-            <li><code>{literal}$mailSetting.source{/literal}</code></li>
-            <li><code>{literal}$mailSetting.is_ssl{/literal}</code></li>
-            <li><code>{literal}$mailSetting.sender_group_id{/literal}</code></li>
-            <li><code>{literal}$mailSetting.recipient_group_id{/literal}</code></li>
-            <li><code>{literal}$mailSetting.subject{/literal}</code></li>
-            <li><code>{literal}$mailSetting.notify_disallowed_sender{/literal}</code></li>
-            <li><code>{literal}$mailSetting.notify_disallowed_sender_template{/literal}</code></li>
-            <li><code>{literal}$mailSetting.notify_sender_errors{/literal}</code></li>
-            <li><code>{literal}$mailSetting.notify_sender_errors_template{/literal}</code></li>
-            <li><code>{literal}$mailSetting.notification_activity_type_id{/literal}</code></li>
-            <li><code>{literal}$mailSetting.archive_mailing{/literal}</code></li>
-          </ul>
-        </li>
+      <code>{literal}$mailSetting{/literal}</code> - Variables of the mail settings used.
+      <ul>
+        <li><code>{literal}$mailSetting.name{/literal}</code></li>
+        <li><code>{literal}$mailSetting.domain{/literal}</code></li>
+        <li><code>{literal}$mailSetting.localpart{/literal}</code></li>
+        <li><code>{literal}$mailSetting.server{/literal}</code></li>
+        <li><code>{literal}$mailSetting.return_path{/literal}</code></li>
+        <li><code>{literal}$mailSetting.protocol{/literal}</code></li>
+        <li><code>{literal}$mailSetting.port{/literal}</code></li>
+        <li><code>{literal}$mailSetting.username{/literal}</code></li>
+        <li><code>{literal}$mailSetting.password{/literal}</code></li>
+        <li><code>{literal}$mailSetting.source{/literal}</code></li>
+        <li><code>{literal}$mailSetting.is_ssl{/literal}</code></li>
+        <li><code>{literal}$mailSetting.sender_group_id{/literal}</code></li>
+        <li><code>{literal}$mailSetting.recipient_group_id{/literal}</code></li>
+        <li><code>{literal}$mailSetting.subject{/literal}</code></li>
+        <li><code>{literal}$mailSetting.notify_disallowed_sender{/literal}</code></li>
+        <li><code>{literal}$mailSetting.notify_disallowed_sender_template{/literal}</code></li>
+        <li><code>{literal}$mailSetting.notify_sender_errors{/literal}</code></li>
+        <li><code>{literal}$mailSetting.notify_sender_errors_template{/literal}</code></li>
+        <li><code>{literal}$mailSetting.notification_activity_type_id{/literal}</code></li>
+        <li><code>{literal}$mailSetting.archive_mailing{/literal}</code></li>
+      </ul>
+    </li>
+
+    <li>
+      <code>{literal}$mailing{/literal}</code> - Variables of the mailing bounces are being processed for.
+    </li>
+
   </ul>
 {/htxt}

--- a/templates/CRM/Admin/Form/MailboxmailingMailSettings.hlp
+++ b/templates/CRM/Admin/Form/MailboxmailingMailSettings.hlp
@@ -134,7 +134,11 @@
     </li>
 
     <li>
-      <code>{literal}$mailing{/literal}</code> - Variables of the mailing bounces are being processed for.
+      <code>{literal}$mailing{/literal}</code> - Variables of the mailing bounces are being processed for:
+      <ul>
+        <li><code>{literal}subject{/literal}</code></li>
+        <li><code>{literal}scheduled_date{/literal}</code></li>
+      </ul>
     </li>
 
   </ul>
@@ -181,7 +185,11 @@
     </li>
 
     <li>
-      <code>{literal}$mailing{/literal}</code> - Variables of the mailing bounces are being processed for.
+      <code>{literal}$mailing{/literal}</code> - Variables of the mailing bounces are being processed for:
+      <ul>
+        <li><code>{literal}subject{/literal}</code></li>
+        <li><code>{literal}scheduled_date{/literal}</code></li>
+      </ul>
     </li>
 
   </ul>


### PR DESCRIPTION
This passes some properties of the *Mailing* object in a new Smarty variable for the subject and body of bounce notification messages being sent to the sender of the original e-mail.

`$mailing` - Variables of the mailing bounces are being processed for:
* `subject`
* `scheduled_date`
